### PR TITLE
make Router.add() chainable

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -12,6 +12,7 @@ class Router {
 
   add = ({ pattern, name, page = addInitialSlash(name) }) => {
     this.routes.push({ pattern, page, name })
+    return this
   }
 
   getRoute = name => {


### PR DESCRIPTION
To make `Router.add()` chainable:

```
const Router = require('nextjs-dynamic-routes')

const router = new Router()

router
  .add({ name: 'Home', pattern: '/' })
  .add({ name: 'Car', pattern: '/car/:make/:model' })

export default router
```
